### PR TITLE
chore: Sync with rhiza

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -8,11 +8,8 @@ templates:
 - core
 - github
 - legal
-- tests
 - github-tests
-- book
 - github-book
-- marimo
 - github-marimo
 files:
 - .bandit
@@ -100,5 +97,5 @@ files:
 - docs/mkdocs-base.yml
 - pytest.ini
 - ruff.toml
-synced_at: '2026-05-10T10:38:40Z'
+synced_at: '2026-05-18T00:18:42Z'
 strategy: merge


### PR DESCRIPTION
## 🔄 Template Synchronization

This PR synchronizes the repository with the [jebel-quant/rhiza](https://github.com/jebel-quant/rhiza) template.

### 📊 Change Summary

- **0** files added
- **1** files modified
- **0** files deleted

### 📁 Changes by Category

#### Rhiza Configuration

<details>
<summary>Modified (1)</summary>

- 📝 `.rhiza/template.lock`

</details>

---

**🤖 Generated by [rhiza](https://github.com/jebel-quant/rhiza-cli)**

- Template: `jebel-quant/rhiza@v0.10.6`
- Last sync: 2026-05-18T00:18:42Z
- Sync date: 2026-05-18T00:18:44.576900+00:00