### PR TITLE
Quality follow-ups: property tests, type/doc fixes (#267–#270)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ radius, centre = min_circle_cvx(points, solver="CLARABEL")
 
 ```
 
+### 🔧 Which solver should I use?
+
+The package ships two entry points that solve the same problem:
+
+- **`min_circle_cvx`** — models the problem with [CVXPY](https://www.cvxpy.org)
+  and dispatches to any conic backend (default: CLARABEL). Most convenient and
+  flexible; carries CVXPY's canonicalisation overhead.
+- **`min_circle_clarabel`** — assembles the second-order cone program directly
+  and calls [Clarabel](https://clarabel.org) without CVXPY. Faster on large
+  inputs since it skips canonicalisation, at the cost of a lower-level API.
+
+Prefer `min_circle_cvx` for convenience and solver flexibility; reach for
+`min_circle_clarabel` when canonicalisation overhead dominates (many points /
+tight loops).
+
 ## 🧮 Background
 
 We are solving the convex optimization problem:

--- a/src/cvxball/solver.py
+++ b/src/cvxball/solver.py
@@ -16,7 +16,7 @@ import numpy as np
 import scipy.sparse as sp
 
 
-def min_circle_cvx(points: np.ndarray, **kwargs: dict[str, Any]) -> tuple[float, np.ndarray]:
+def min_circle_cvx(points: np.ndarray, **kwargs: Any) -> tuple[float, np.ndarray]:
     """Compute the smallest enclosing circle for a set of points using convex optimization.
 
     This function solves the convex optimization problem to find the minimum radius

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,11 +1,36 @@
 """Tests for the convex minimum enclosing circle solver utilities."""
 
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from hypothesis.extra.numpy import arrays
 
 from cvxball.solver import min_circle_clarabel, min_circle_cvx
+
+
+def _cvx(points: np.ndarray) -> tuple[float, np.ndarray]:
+    """Adapter so `min_circle_cvx` matches the `min_circle_clarabel` signature."""
+    return min_circle_cvx(points, solver="CLARABEL")
+
+
+# Parametrize the analytic tests over both solvers; they must agree on the
+# (unique) minimum enclosing ball.
+_both_solvers = pytest.mark.parametrize("solver", [_cvx, min_circle_clarabel], ids=["cvx", "clarabel"])
+
+# Bounded, finite coordinates keep the conic programs well-conditioned.
+_coords = st.floats(min_value=-100.0, max_value=100.0, allow_nan=False, allow_infinity=False, width=64)
+
+
+@st.composite
+def _point_clouds(draw: st.DrawFn) -> np.ndarray:
+    """Draw an (n, d) array of n points in d dimensions with finite coordinates."""
+    n = draw(st.integers(min_value=1, max_value=15))
+    d = draw(st.integers(min_value=1, max_value=4))
+    return draw(arrays(dtype=np.float64, shape=(n, d), elements=_coords))
 
 
 def test_random():
@@ -61,3 +86,78 @@ def test_min_circle_clarabel_non_converged():
         mock_solver_cls.return_value.solve.return_value = bad_solution
         with pytest.raises(ValueError, match="Clarabel did not converge"):
             min_circle_clarabel(p)
+
+
+# --- Property-based tests (issue #267) -----------------------------------------
+
+
+@pytest.mark.property
+@settings(deadline=None, max_examples=25)
+@given(points=_point_clouds())
+def test_ball_encloses_all_points_cvx(points: np.ndarray) -> None:
+    """`min_circle_cvx` returns a ball that contains every point and is tight."""
+    radius, center = _cvx(points)
+    distances = np.linalg.norm(points - center, axis=1)
+    # Containment: every point lies inside (or on) the ball.
+    assert np.all(distances <= radius + 1e-4 + 1e-5 * abs(radius))
+    # Tightness/minimality: the radius equals the farthest distance (binding constraint).
+    assert distances.max() == pytest.approx(radius, abs=1e-3, rel=1e-5)
+
+
+@pytest.mark.property
+@settings(deadline=None, max_examples=25)
+@given(points=_point_clouds())
+def test_ball_encloses_all_points_clarabel(points: np.ndarray) -> None:
+    """`min_circle_clarabel` returns a ball that contains every point and is tight."""
+    radius, center = min_circle_clarabel(points)
+    distances = np.linalg.norm(points - center, axis=1)
+    assert np.all(distances <= radius + 1e-4 + 1e-5 * abs(radius))
+    assert distances.max() == pytest.approx(radius, abs=1e-3, rel=1e-5)
+
+
+@pytest.mark.property
+@settings(deadline=None, max_examples=25)
+@given(points=_point_clouds())
+def test_solvers_agree_on_radius(points: np.ndarray) -> None:
+    """Both solvers agree on the (unique) minimum enclosing radius."""
+    radius_cvx, _ = _cvx(points)
+    radius_clarabel, _ = min_circle_clarabel(points)
+    assert radius_cvx == pytest.approx(radius_clarabel, abs=1e-3, rel=1e-4)
+
+
+# --- Degenerate inputs (issue #269) --------------------------------------------
+
+
+@_both_solvers
+def test_single_point(solver: Callable[[np.ndarray], tuple[float, np.ndarray]]) -> None:
+    """A single point gives radius 0 centred on that point."""
+    radius, center = solver(np.array([[3.0, -1.0]]))
+    assert radius == pytest.approx(0.0, abs=1e-5)
+    assert center == pytest.approx([3.0, -1.0], abs=1e-4)
+
+
+@_both_solvers
+def test_duplicate_points_match_unique(solver: Callable[[np.ndarray], tuple[float, np.ndarray]]) -> None:
+    """Duplicated points yield the same ball as the deduplicated set."""
+    unique = np.array([[0.0, 0.0], [4.0, 0.0], [2.0, 3.0]])
+    duplicated = np.vstack([unique, unique, unique[:1]])
+    radius_u, center_u = solver(unique)
+    radius_d, center_d = solver(duplicated)
+    assert radius_d == pytest.approx(radius_u, rel=1e-5)
+    assert center_d == pytest.approx(center_u, abs=1e-4)
+
+
+@_both_solvers
+def test_collinear_points(solver: Callable[[np.ndarray], tuple[float, np.ndarray]]) -> None:
+    """Collinear points: the two extremes form the diameter."""
+    radius, center = solver(np.array([[0.0, 0.0], [1.0, 0.0], [4.0, 0.0]]))
+    assert radius == pytest.approx(2.0, abs=1e-4)  # (4 - 0) / 2
+    assert center == pytest.approx([2.0, 0.0], abs=1e-4)
+
+
+@_both_solvers
+def test_one_dimensional_points(solver: Callable[[np.ndarray], tuple[float, np.ndarray]]) -> None:
+    """1-D inputs: radius = (max - min) / 2, centred at the midpoint."""
+    radius, center = solver(np.array([[-3.0], [1.0], [5.0]]))
+    assert radius == pytest.approx(4.0, abs=1e-4)  # (5 - (-3)) / 2
+    assert center == pytest.approx([1.0], abs=1e-4)


### PR DESCRIPTION
Addresses the four quality issues opened from the `/rhiza_quality` scorecard. **Based on `sync/rhiza-v0.19.5` (#266)** so the diff shows only these changes; GitHub will retarget to `main` once #266 merges.

| Issue | Change | File(s) |
|-------|--------|---------|
| Closes #267 | Property-based tests for the enclosing-ball invariant (containment + tightness) and cross-solver radius agreement, via `hypothesis` (`@pytest.mark.property`). | `tests/test_solver.py` |
| Closes #268 | `**kwargs: dict[str, Any]` → `**kwargs: Any` (the values are scalars like `solver="CLARABEL"`, not dicts). | `src/cvxball/solver.py` |
| Closes #269 | Degenerate-input tests parametrized over both solvers: single point, duplicates, collinear, 1-D. | `tests/test_solver.py` |
| Closes #270 | "Which solver should I use?" note (cvx vs clarabel tradeoff). | `README.md` |

### Test impact
- Suite grows 5 → **16** tests; coverage stays **100%**.
- The 3 property tests are picked up by `make hypothesis-test` (`-m "hypothesis or property"`); all 25-example runs pass.

### Gates (all green locally)
`make fmt` ✅ · `typecheck` ✅ · `docs-coverage` ✅ (100%) · `deptry` ✅ · `security` ✅ · `validate` ✅ · `test` ✅ (16 passed) · `book` ✅

> Note: the API-docs build fix (`paths: [src]` in `mkdocs.yml`) lives on **#266**, since the `make book` regression was introduced by the v0.19.5 sync — it is inherited here via the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)