### PR TITLE
Fix: avoid deprecated CVXPY `*`-as-matmul in min_circle_cvx (#273)

### DIFF
--- a/src/cvxball/solver.py
+++ b/src/cvxball/solver.py
@@ -47,7 +47,10 @@ def min_circle_cvx(points: np.ndarray, **kwargs: Any) -> tuple[float, np.ndarray
     objective = cp.Minimize(r)
     constraints: list[cp.Constraint] = [
         cp.SOC(
-            r * np.ones(points.shape[0]),
+            # Elementwise broadcast of the scalar radius across all points.
+            # `cp.multiply` (not `*`) avoids CVXPY's deprecated `*`-as-matmul
+            # path, which is ambiguous when n == 1 ((1,) * (1,) -> dot product).
+            cp.multiply(r, np.ones(points.shape[0])),  # type: ignore[attr-defined]  # cvxpy re-exports atoms via star-import; stubs don't expose them
             points - x,  # Broadcasting handles this automatically
             axis=1,
         )


### PR DESCRIPTION
## Summary

Fixes #273. `src/cvxball/solver.py` built the SOC constraint's radius vector with `r * np.ones(n)`, which routes through CVXPY's deprecated `*`-as-matrix-multiplication path. It was ambiguous for `n == 1`, where `(1,) * (1,)` collapses to a dot product, emitting `CvxpyDeprecationWarning`/`UserWarning` — 24 per test run, surfaced by the degenerate/property-based tests.

## Change

```diff
-            r * np.ones(points.shape[0]),
+            cp.multiply(r, np.ones(points.shape[0])),  # type: ignore[attr-defined]
```

`cp.multiply` is the explicit elementwise atom and is unambiguous for all `n`. The targeted `# type: ignore[attr-defined]` is needed because cvxpy re-exports its atoms via star-import and its stubs don't expose them (`ty` resolves it; `mypy --strict` does not) — consistent with the existing clarabel/scipy stub-gap handling in this file.

## Verification

- [x] **0** matmul-deprecation warnings (was 24)
- [x] `make test` — 16 passed, **100% coverage**
- [x] `make fmt` — clean (ruff, bandit, interrogate)
- [x] `make typecheck` — `ty` + `mypy --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)