### PR TITLE
chore(pyproject): declare explicit Python version classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,6 @@ requires-python = ">=3.11,<3.14"
 license = {text = "MIT"}
 classifiers = [
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
One trove classifier per supported Python version instead of the generic `Programming Language :: Python :: 3` rows.

- `requires-python` is 3.11,<3.14", so the classifiers are: **3.11,3.12,3.13**
- removed `Programming Language :: Python :: 3` and `Programming Language :: Python :: 3 :: Only`

Metadata only — no source, dependency, or tooling changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
