### PR TITLE
chore(pyproject): modernize Python version and license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,12 @@ description = "Fast computation of the smallest enclosing sphere"
 authors = [{name='Thomas Schmelzer', email= 'thomas.schmelzer@gmail.com'}]
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
-license = {text = "MIT"}
+license = "MIT"
 classifiers = [
     "Private :: Do Not Upload",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "License :: OSI Approved :: MIT License",
 ]
 
 dependencies = [


### PR DESCRIPTION
Modernizes the `[project]` metadata in `pyproject.toml`.

**License** — dropped the `License :: OSI Approved :: MIT License` classifier, which PEP 639 deprecates in favour of the `license` SPDX expression, and moved `license` from the deprecated `{text = "MIT"}` table form to the SPDX string `"MIT"`. Backends implementing PEP 639 reject a project that declares both.

The explicit Python version classifiers landed separately in #299.

Metadata only — no source, dependency, or tooling changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
